### PR TITLE
docs: clarify Vial GUI labels vs QMK API mapping for tap-hold settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,21 @@ Keymaps for VIA/Vial are in `keyboards/<kb>/qmk/qmk_firmware/keymaps/via/keymap.
 
 Vial keymaps additionally include `vial.json` (Vial UI layout definition) and `config.h`/`rules.mk`.
 
+### Vial GUI labels vs QMK API mapping
+
+The tap-hold toggles in Vial GUI's QMK Settings tab use QMK's old API names (hardcoded in vial-kb/vial-gui's `src/main/resources/base/qmk_settings.json`). Vial-QMK firmware has migrated to the new API, so the mapping is:
+
+| Vial GUI label            | QSID/bit    | Internal function              | Effect when checked                                  | QMK API                                   |
+|---------------------------|-------------|--------------------------------|------------------------------------------------------|-------------------------------------------|
+| Permissive Hold           | QSID=8 bit0 | `get_permissive_hold`          | Permissive Hold ON                                   | `PERMISSIVE_HOLD`                         |
+| Ignore Mod Tap Interrupt  | QSID=8 bit1 | `get_hold_on_other_key_press`  | `HOLD_ON_OTHER_KEY_PRESS` **OFF** (inverted)         | opposite of `HOLD_ON_OTHER_KEY_PRESS`     |
+| Tapping Force Hold        | QSID=8 bit2 | `get_quick_tap_term`           | `QUICK_TAP_TERM` set to 0 (suppresses repeat-tap hold) | `QUICK_TAP_TERM`                        |
+| Retro Tapping             | QSID=8 bit3 | `get_retro_tapping`            | Retro Tapping ON                                     | `RETRO_TAPPING`                           |
+
+Note: "Ignore Mod Tap Interrupt" is inverted — leaving it **unchecked** (default) is equivalent to `HOLD_ON_OTHER_KEY_PRESS` being enabled.
+
+Reference: `src/vial-kb/vial-qmk/quantum/qmk_settings.c` (around line 263–281)
+
 ## CI
 
 Two GitHub Actions workflows run on every push, each uploading the `.uf2` as a workflow artifact:

--- a/keyboards/crkbd/vial-kb/vial-qmk/keymaps/vial/config.h
+++ b/keyboards/crkbd/vial-kb/vial-qmk/keymaps/vial/config.h
@@ -3,7 +3,3 @@
 #define VIAL_KEYBOARD_UID {0x89, 0x36, 0x2A, 0xC7, 0xFA, 0xD8, 0x89, 0x45}
 #define VIAL_UNLOCK_COMBO_ROWS {0, 0}
 #define VIAL_UNLOCK_COMBO_COLS {0, 1}
-
-// Tap-hold: 他キーが押された瞬間に hold 側として確定する (タップタームの満了を待たない)
-// https://docs.qmk.fm/tap_hold#hold-on-other-key-press
-#define HOLD_ON_OTHER_KEY_PRESS

--- a/keyboards/crkbd/vial-kb/vial-qmk/keymaps/vial/config.h
+++ b/keyboards/crkbd/vial-kb/vial-qmk/keymaps/vial/config.h
@@ -3,3 +3,7 @@
 #define VIAL_KEYBOARD_UID {0x89, 0x36, 0x2A, 0xC7, 0xFA, 0xD8, 0x89, 0x45}
 #define VIAL_UNLOCK_COMBO_ROWS {0, 0}
 #define VIAL_UNLOCK_COMBO_COLS {0, 1}
+
+// Tap-hold: 他キーが押された瞬間に hold 側として確定する (タップタームの満了を待たない)
+// https://docs.qmk.fm/tap_hold#hold-on-other-key-press
+#define HOLD_ON_OTHER_KEY_PRESS


### PR DESCRIPTION
## Summary

- Vial GUI の QMK Settings タブの tap-hold トグルは QMK 旧 API 名のラベルのまま (vial-kb/vial-gui 側の制約)
- 特に「Ignore Mod Tap Interrupt」チェックが内部的に `HOLD_ON_OTHER_KEY_PRESS` を **反転** 制御している点が分かりにくいため、対応表を `CLAUDE.md` に記録
- あわせて当初追加した `#define HOLD_ON_OTHER_KEY_PRESS` を削除 — `QMK_SETTINGS` 有効時は `build_vial.mk` が `HOLD_ON_OTHER_KEY_PRESS_PER_KEY` を自動定義するため `action_tapping.c` 側で無視されており、誤解を招くだけだったため

## Test plan

- [x] `CLAUDE.md` の対応表が GitHub 上で正しくレンダリングされること
- [ ] CI (`build-vial.yml`) がグリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)